### PR TITLE
Bug/165 - Fix completing timer when paused

### DIFF
--- a/public/actions.js
+++ b/public/actions.js
@@ -795,7 +795,6 @@ export const UpdateSettings = state => {
 
 export const UpdateByWebsocketData = (state, { payload }) => {
   const { type, ...data } = payload;
-
   switch (type) {
     case 'settings:update':
       return {
@@ -825,7 +824,7 @@ export const UpdateByWebsocketData = (state, { payload }) => {
       };
 
     case 'timer:complete':
-      if (state.timerStartedAt === null) {
+      if (state.timerDuration === 0) {
         return state;
       }
 

--- a/public/actions.js
+++ b/public/actions.js
@@ -824,7 +824,7 @@ export const UpdateByWebsocketData = (state, { payload }) => {
       };
 
     case 'timer:complete':
-      if (state.timerDuration === 0) {
+      if (state.timerStartedAt === null && state.timerDuration === 0) {
         return state;
       }
 

--- a/public/actions.websocket-messages.test.js
+++ b/public/actions.websocket-messages.test.js
@@ -118,6 +118,30 @@ test('can complete timer from websocket message', t => {
   );
 });
 
+test('can complete a paused timer from websocket message', t => {
+  const initialState = {
+    timerStartedAt: null,
+    timerDuration: 5000,
+  };
+
+  const [state, effect] = actions.UpdateByWebsocketData(initialState, {
+    payload: {
+      type: 'timer:complete',
+    },
+    documentElement: {},
+    Notification: {},
+  });
+
+  t.is(state, initialState);
+  t.deepEqual(
+    effect,
+    effects.andThen({
+      action: actions.EndTurn,
+      props: {},
+    }),
+  );
+});
+
 test('can skip complete timer from websocket message if timer already over', t => {
   const initialState = {
     timerStartedAt: null,

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -41,7 +41,7 @@ export const ShareMessage = (timerId, connections, message, queue) =>
   defer(
     queue.getTimer(timerId).then(timer => {
       const { type } = JSON.parse(message);
-      if (type === 'timer:complete' && !timer.timerStartedAt) {
+      if (type === 'timer:complete' && timer.timerDuration === 0) {
         return none('ShareMessageNone');
       }
 

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -41,7 +41,11 @@ export const ShareMessage = (timerId, connections, message, queue) =>
   defer(
     queue.getTimer(timerId).then(timer => {
       const { type } = JSON.parse(message);
-      if (type === 'timer:complete' && timer.timerDuration === 0) {
+      if (
+        type === 'timer:complete' &&
+        !timer.timerStartedAt &&
+        timer.timerDuration === 0
+      ) {
         return none('ShareMessageNone');
       }
 

--- a/src/websocket.test.js
+++ b/src/websocket.test.js
@@ -68,7 +68,10 @@ test('ShareMessage prevents timer complete cascade', async t => {
   ];
   const timerId = 'foo';
   const queue = Queue.forTesting({
-    [`timer_${timerId}`]: JSON.stringify({ timerStartedAt: null }),
+    [`timer_${timerId}`]: JSON.stringify({
+      timerStartedAt: null,
+      timerDuration: 0,
+    }),
   });
 
   const { ok } = await tester()


### PR DESCRIPTION
Resolves #165 

In the test `can skip complete timer from websocket message if timer already over`, it was passing in `timerStartedAt: null` and `timerDuration: 0`, but `actions.js` checked if the `timerStartedAt` was `null`. Which happens to also be null when the timer is paused.

This caused pausing the timer then completing it to not sync across clients. Changing it to `timerDuration` seemed to fix the problem for me and not break any existing tests.