### PR TITLE
Fix for chromium-based browsers

### DIFF
--- a/public/actions.js
+++ b/public/actions.js
@@ -53,7 +53,8 @@ export const Init = (_, { timerId, externals, dark }) => [
     name: '',
     goal: '',
     addMultiple: false,
-    allowNotification: externals.Notification.permission === 'granted',
+    allowNotification:
+      externals.Notification && externals.Notification.permission === 'granted',
     allowSound: false,
     sound: 'horn',
     pendingSettings: {},
@@ -649,7 +650,8 @@ export const UpdateNotificationPermissions = state => [
   {
     ...state,
   },
-  state.externals.Notification.permission === 'granted' &&
+  state.externals.Notification &&
+    state.externals.Notification.permission === 'granted' &&
     effects.andThen({
       action: SetAllowNotification,
       props: { allowNotification: true },


### PR DESCRIPTION
@mrozbarry This was the solution we came up with during the growth session to debug this, and seemed to allow the timer page to load and work again in the plugin. If there might be a better way to solve this, let's set up another growth session to explore it 😄 

### **Problem:**
The intelliJ mobtime plugin uses the chromium embedded framework under the hood (through [JBCef](https://plugins.jetbrains.com/docs/intellij/jcef.html?from=jetbrains.org)), and it seems that `window.Notification` is not supported by chromium browsers (assumption from here: https://developer.mozilla.org/en-US/docs/Web/API/notification), but we are trying to access a `permission` property from `window.Notification`,
this causes the plugin to show a blank screen when mobtime errors out: 
![Screen Shot 2022-01-26 at 11 56 53 AM](https://user-images.githubusercontent.com/10167488/151209900-2c84bbc2-0874-49a5-b8e6-67942a03d755.png)

Mobtime source:
In `timer.js`, the `externals` object is defined:

```js
app({
  init: actions.Init(null, {
    timerId: initialTimerId,
    externals: {
      documentElement: window.document,
      Notification: window.Notification, // window.Notification does not seem to be defined for chromium-based browsers
      storage: window.localStorage,
      location: window.location,
      history: window.history,
    },
    dark: 'dark' in flags,
  })
```

and in `public/actions.js`, we try assessing `externals.Notification.permission`:
```js
allowNotification: externals.Notification.permission === 'granted',
```
and
```js
state.externals.Notification.permission === 'granted'
```

### **Solution:**
Check that `externals.Notification` is defined before accessing the `permission` property:
```js
allowNotification:
      externals.Notification && externals.Notification.permission === 'granted',
```
and 
```js
state.externals.Notification &&
    state.externals.Notification.permission === 'granted'
```
